### PR TITLE
refactor: make the bitblasting interface explicit

### DIFF
--- a/src/unicorn/bitblasting_dimacs.rs
+++ b/src/unicorn/bitblasting_dimacs.rs
@@ -1,4 +1,4 @@
-use crate::unicorn::bitblasting::{Gate, GateRef, HashableGateRef};
+use crate::unicorn::bitblasting::{Gate, GateModel, GateRef, HashableGateRef};
 use crate::unicorn::{Model, Node, NodeRef};
 use anyhow::Result;
 use std::collections::HashMap;
@@ -8,11 +8,14 @@ use std::io::Write;
 // Public Interface
 //
 
-pub fn write_dimacs_model<W>(model: &Model, bad_state_gates: &[GateRef], out: W) -> Result<()>
+pub fn write_dimacs_model<W>(model: &Model, gate_model: &GateModel, out: W) -> Result<()>
 where
     W: Write,
 {
-    let zip = model.bad_states_initial.iter().zip(bad_state_gates.iter());
+    let zip = model
+        .bad_states_initial
+        .iter()
+        .zip(gate_model.bad_state_gates.iter());
     let mut builder = CNFBuilder::new();
     for (bad_state, gate) in zip {
         builder.convert_bad_state(bad_state, gate);

--- a/src/unicorn/bitblasting_printer.rs
+++ b/src/unicorn/bitblasting_printer.rs
@@ -1,4 +1,4 @@
-use crate::unicorn::bitblasting::{Gate, GateRef, HashableGateRef};
+use crate::unicorn::bitblasting::{Gate, GateModel, GateRef, HashableGateRef};
 use crate::unicorn::{Model, Nid, Node, NodeRef};
 use anyhow::Result;
 use std::collections::HashMap;
@@ -8,11 +8,14 @@ use std::io::Write;
 // Public Interface
 //
 
-pub fn write_btor2_model<W>(model: &Model, bad_state_gates: &[GateRef], out: W) -> Result<()>
+pub fn write_btor2_model<W>(model: &Model, gate_model: &GateModel, out: W) -> Result<()>
 where
     W: Write,
 {
-    let zip = model.bad_states_initial.iter().zip(bad_state_gates.iter());
+    let zip = model
+        .bad_states_initial
+        .iter()
+        .zip(gate_model.bad_state_gates.iter());
     let mut printer = GateModelPrinter::new(out);
     printer.print_file_header()?;
     for (bad_state, gate) in zip {


### PR DESCRIPTION
This splits the bitblasting implementation into a public interface and a
private implementation. It also makes the output of bitblasting explicit
by encapsulating it in a `GateModel` struct.

Note: This is intended to be a pure refactoring to make the output more obvious. No function changes intended.