### PR TITLE
refactor: simplify `Qubit` struct handling

### DIFF
--- a/src/unicorn/qubot.rs
+++ b/src/unicorn/qubot.rs
@@ -4,117 +4,82 @@ use crate::unicorn::HashableNodeRef;
 use crate::unicorn::NodeRef;
 use anyhow::Result;
 use log::info;
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::io::Write;
-use std::rc::Rc;
 
-pub type QubitRef = Rc<RefCell<Qubit>>;
-
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Qubit {
     pub name: u64,
 }
 
-impl From<Qubit> for QubitRef {
-    fn from(qubit: Qubit) -> Self {
-        Rc::new(RefCell::new(qubit))
-    }
-}
-
-#[derive(Debug)]
-pub struct HashableQubitRef {
-    pub value: QubitRef,
-}
-
-impl Eq for HashableQubitRef {}
-
-impl PartialEq for HashableQubitRef {
-    fn eq(&self, other: &Self) -> bool {
-        RefCell::as_ptr(&self.value) == RefCell::as_ptr(&other.value)
-    }
-}
-
-impl From<QubitRef> for HashableQubitRef {
-    fn from(qubit: QubitRef) -> Self {
-        Self { value: qubit }
-    }
-}
-
-impl Hash for HashableQubitRef {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        RefCell::as_ptr(&self.value).hash(state);
-    }
-}
-
 pub enum Rule {
     Not {
-        x1: QubitRef,
+        x1: Qubit,
     },
     And {
-        x1: QubitRef,
-        x2: QubitRef,
+        x1: Qubit,
+        x2: Qubit,
     },
     Nand {
-        x1: QubitRef,
-        x2: QubitRef,
+        x1: Qubit,
+        x2: Qubit,
     },
     Matriarch1 {
-        x1: QubitRef,
-        x2: QubitRef,
+        x1: Qubit,
+        x2: Qubit,
     },
     Or {
-        x1: QubitRef,
-        x2: QubitRef,
+        x1: Qubit,
+        x2: Qubit,
     },
     AuxHalfAdder {
-        x1: QubitRef,
-        x2: QubitRef,
+        x1: Qubit,
+        x2: Qubit,
     },
     AuxFullAdder {
-        x1: QubitRef,
-        x2: QubitRef,
-        x3: QubitRef,
+        x1: Qubit,
+        x2: Qubit,
+        x3: Qubit,
     },
     CarryHalfAdder {
-        x1: QubitRef,
-        x2: QubitRef,
+        x1: Qubit,
+        x2: Qubit,
     },
     CarryFullAdder {
-        x1: QubitRef,
-        x2: QubitRef,
-        x3: QubitRef,
+        x1: Qubit,
+        x2: Qubit,
+        x3: Qubit,
     },
     ResultHalfAdder {
-        x1: QubitRef,
-        x2: QubitRef,
+        x1: Qubit,
+        x2: Qubit,
     },
     ResultFullAdder {
-        x1: QubitRef,
-        x2: QubitRef,
-        x3: QubitRef,
+        x1: Qubit,
+        x2: Qubit,
+        x3: Qubit,
     },
     Invalid,
     Quotient {
-        dividend: Vec<QubitRef>,
-        divisor: Vec<QubitRef>,
+        dividend: Vec<Qubit>,
+        divisor: Vec<Qubit>,
         index: u32,
     },
     Remainder {
-        dividend: Vec<QubitRef>,
-        divisor: Vec<QubitRef>,
+        dividend: Vec<Qubit>,
+        divisor: Vec<Qubit>,
         index: u32,
     },
 }
 
 pub struct Qubo {
-    pub linear_coefficients: HashMap<HashableQubitRef, f64>,
-    pub quadratic_coefficients: HashMap<HashableQubitRef, HashMap<HashableQubitRef, f64>>,
+    pub linear_coefficients: HashMap<Qubit, f64>,
+    pub quadratic_coefficients: HashMap<Qubit, HashMap<Qubit, f64>>,
     pub offset: f64,
-    rules: HashMap<HashableQubitRef, Rule>, // used when we want to evaluate an input
-    pub fixed_variables: HashMap<HashableQubitRef, bool>, // used for when we want to evaluate an input
+    rules: HashMap<Qubit, Rule>, // used when we want to evaluate an input
+    pub fixed_variables: HashMap<Qubit, bool>, // used for when we want to evaluate an input
     pub is_ising: bool,
 }
 
@@ -141,19 +106,17 @@ impl Qubo {
 
         for (node, neighbours) in self.quadratic_coefficients.iter_mut() {
             for (neighbour, value) in neighbours.iter_mut() {
-                if (*node).value.borrow().name < (*neighbour).value.borrow().name {
+                if node.name < neighbour.name {
                     if let Some(unwrapped_node) = self.linear_coefficients.get_mut(node) {
                         *unwrapped_node += 0.25 * (*value);
                     } else {
-                        let key = HashableQubitRef::from((*node).value.clone());
-                        self.linear_coefficients.insert(key, 0.25 * (*value));
+                        self.linear_coefficients.insert(*node, 0.25 * (*value));
                     }
 
                     if let Some(unwrapped_node) = self.linear_coefficients.get_mut(neighbour) {
                         *unwrapped_node += 0.25 * (*value);
                     } else {
-                        let key = HashableQubitRef::from((*neighbour).value.clone());
-                        self.linear_coefficients.insert(key, 0.25 * (*value));
+                        self.linear_coefficients.insert(*neighbour, 0.25 * (*value));
                     }
                     quadratic_offset += *value;
                 }
@@ -164,60 +127,46 @@ impl Qubo {
     }
 
     pub fn get_count_variables(&self) -> usize {
-        let set1: HashSet<u64> = self
-            .linear_coefficients
-            .keys()
-            .map(|x| (*x).value.borrow().name)
-            .collect();
-        let set2: HashSet<u64> = self
-            .quadratic_coefficients
-            .keys()
-            .map(|x| (*x).value.borrow().name)
-            .collect();
+        let set1: HashSet<u64> = self.linear_coefficients.keys().map(|x| x.name).collect();
+        let set2: HashSet<u64> = self.quadratic_coefficients.keys().map(|x| x.name).collect();
 
         set1.union(&set2).count()
     }
 
-    pub fn add_rule(&mut self, qubit: &QubitRef, value: Rule) {
-        let key = HashableQubitRef::from(qubit.clone());
-        assert!(self.rules.insert(key, value).is_none())
+    pub fn add_rule(&mut self, qubit: Qubit, value: Rule) {
+        assert!(self.rules.insert(qubit, value).is_none())
     }
 
-    pub fn add_linear_coeff(&mut self, qubit: &QubitRef, value: f64) {
+    pub fn add_linear_coeff(&mut self, qubit: Qubit, value: f64) {
         if value == 0.0 {
             return;
         }
-        let key = HashableQubitRef::from(qubit.clone());
-        let entry = self.linear_coefficients.entry(key).or_insert(0.0);
+        let entry = self.linear_coefficients.entry(qubit).or_insert(0.0);
         *entry += value;
     }
 
-    fn add_new_row(&mut self, qubit: &QubitRef) {
-        let key = HashableQubitRef::from(qubit.clone());
+    fn add_new_row(&mut self, qubit: Qubit) {
         self.quadratic_coefficients
-            .entry(key)
+            .entry(qubit)
             .or_insert_with(HashMap::new);
     }
 
-    fn insert_quadratic_coeff(&mut self, qubit1: &QubitRef, qubit2: &QubitRef, value: f64) {
-        let key1 = HashableQubitRef::from(qubit1.clone());
-        let key2 = HashableQubitRef::from(qubit2.clone());
+    fn insert_quadratic_coeff(&mut self, qubit1: Qubit, qubit2: Qubit, value: f64) {
+        let hashmap: &mut HashMap<Qubit, f64> =
+            self.quadratic_coefficients.get_mut(&qubit1).unwrap();
 
-        let hashmap: &mut HashMap<HashableQubitRef, f64> =
-            self.quadratic_coefficients.get_mut(&key1).unwrap();
-
-        if hashmap.contains_key(&key2) {
-            let new_coeff = value + hashmap.get(&key2).unwrap();
-            hashmap.insert(key2, new_coeff);
+        if hashmap.contains_key(&qubit2) {
+            let new_coeff = value + hashmap.get(&qubit2).unwrap();
+            hashmap.insert(qubit2, new_coeff);
         } else {
-            hashmap.insert(key2, value);
+            hashmap.insert(qubit2, value);
         }
     }
 
-    pub fn add_quadratic_coeffs(&mut self, qubit1: &QubitRef, qubit2: &QubitRef, value: f64) {
+    pub fn add_quadratic_coeffs(&mut self, qubit1: Qubit, qubit2: Qubit, value: f64) {
         if value == 0.0 {
             return;
-        } else if qubit1.borrow().name == qubit2.borrow().name {
+        } else if qubit1 == qubit2 {
             return self.add_linear_coeff(qubit1, value);
         }
 
@@ -234,49 +183,43 @@ impl Qubo {
         self.offset
     }
 
-    pub fn fix_variable(&mut self, qubit: &QubitRef, value: bool) {
+    pub fn fix_variable(&mut self, qubit: Qubit, value: bool) {
         let num: f64 = (value as i64) as f64;
 
-        let key = HashableQubitRef::from(qubit.clone());
-        self.fixed_variables.insert(key, value);
-        let key = HashableQubitRef::from(qubit.clone());
+        self.fixed_variables.insert(qubit, value);
 
         assert!(
-            self.linear_coefficients.contains_key(&key)
-                || self.quadratic_coefficients.contains_key(&key)
+            self.linear_coefficients.contains_key(&qubit)
+                || self.quadratic_coefficients.contains_key(&qubit)
         );
 
-        if self.linear_coefficients.contains_key(&key) {
-            let coeff = self.linear_coefficients.get(&key).unwrap();
+        if self.linear_coefficients.contains_key(&qubit) {
+            let coeff = self.linear_coefficients.get(&qubit).unwrap();
             self.offset += coeff * num;
-            self.linear_coefficients.remove(&key);
+            self.linear_coefficients.remove(&qubit);
         }
 
-        if self.quadratic_coefficients.contains_key(&key) {
-            let hashmap = <&HashMap<HashableQubitRef, f64>>::clone(
-                &self.quadratic_coefficients.get(&key).unwrap(),
-            );
-            let pairs: Vec<(QubitRef, f64)> =
-                hashmap.iter().map(|(x, y)| (x.value.clone(), *y)).collect();
-            for (qubit_ref, value) in pairs {
-                self.add_linear_coeff(&qubit_ref, value * num);
-                let key2 = HashableQubitRef::from(qubit_ref);
+        if self.quadratic_coefficients.contains_key(&qubit) {
+            let hashmap = self.quadratic_coefficients.get(&qubit).unwrap();
+            let pairs: Vec<(Qubit, f64)> = hashmap.iter().map(|(x, y)| (*x, *y)).collect();
+            for (qubit2, value) in pairs {
+                self.add_linear_coeff(qubit2, value * num);
                 self.quadratic_coefficients
-                    .get_mut(&key2)
+                    .get_mut(&qubit2)
                     .unwrap()
-                    .remove(&key);
+                    .remove(&qubit);
             }
-            self.quadratic_coefficients.remove(&key);
+            self.quadratic_coefficients.remove(&qubit);
         }
     }
 }
 
 pub struct Qubot<'a> {
     pub qubo: Qubo,
-    pub mapping: HashMap<HashableGateRef, QubitRef>,
-    mapping_carries: HashMap<HashableGateRef, QubitRef>, // ResultHalfAdder or ResultFullAdder -> to Qubit that represent carries
-    const_true_qubit: QubitRef,
-    const_false_qubit: QubitRef,
+    pub mapping: HashMap<HashableGateRef, Qubit>,
+    mapping_carries: HashMap<HashableGateRef, Qubit>, // ResultHalfAdder or ResultFullAdder -> to Qubit that represent carries
+    const_true_qubit: Qubit,
+    const_false_qubit: Qubit,
     gate_model: &'a GateModel,
     current_index: u64,
 }
@@ -287,18 +230,16 @@ impl<'a> Qubot<'a> {
             qubo: Qubo::new(is_ising),
             mapping: HashMap::new(),
             mapping_carries: HashMap::new(),
-            const_false_qubit: QubitRef::new(RefCell::new(Qubit { name: 0 })),
-            const_true_qubit: QubitRef::new(RefCell::new(Qubit { name: 1 })),
+            const_false_qubit: Qubit { name: 0 },
+            const_true_qubit: Qubit { name: 1 },
             gate_model: model,
             current_index: 1,
         }
     }
 
-    pub fn get_qubit_value(&self, qubit: &QubitRef) -> Option<bool> {
-        let key_qubit = HashableQubitRef::from(qubit.clone());
-
-        if self.qubo.fixed_variables.contains_key(&key_qubit) {
-            Some(*self.qubo.fixed_variables.get(&key_qubit).unwrap())
+    pub fn get_qubit_value(&self, qubit: Qubit) -> Option<bool> {
+        if self.qubo.fixed_variables.contains_key(&qubit) {
+            Some(*self.qubo.fixed_variables.get(&qubit).unwrap())
         } else {
             None
         }
@@ -317,9 +258,9 @@ impl<'a> Qubot<'a> {
 
         let mut coeffs: Vec<f64> = Vec::new();
         for (qubit1, edges) in self.qubo.quadratic_coefficients.iter() {
-            let id1 = (*qubit1.value.borrow()).name;
+            let id1 = qubit1.name;
             for (qubit2, coeff) in edges.iter() {
-                let id2 = (*qubit2.value.borrow()).name;
+                let id2 = qubit2.name;
                 if id1 < id2 {
                     coeffs.push(*coeff);
                 }
@@ -336,9 +277,9 @@ impl<'a> Qubot<'a> {
 
         let mut connect_map: HashMap<u64, u32> = HashMap::new();
         for (qubit1, edges) in self.qubo.quadratic_coefficients.iter() {
-            let id1 = (*qubit1.value.borrow()).name;
+            let id1 = qubit1.name;
             for (qubit2, _) in edges.iter() {
-                let id2 = (*qubit2.value.borrow()).name;
+                let id2 = qubit2.name;
                 if id1 < id2 {
                     *connect_map.entry(id1).or_insert(0) += 1;
                     *connect_map.entry(id2).or_insert(0) += 1;
@@ -360,7 +301,7 @@ impl<'a> Qubot<'a> {
         );
     }
 
-    pub fn dump_model<W>(&self, mut out: W, bad_state_qubits: Vec<(QubitRef, u64)>) -> Result<()>
+    pub fn dump_model<W>(&self, mut out: W, bad_state_qubits: Vec<(Qubit, u64)>) -> Result<()>
     where
         W: Write,
     {
@@ -379,9 +320,9 @@ impl<'a> Qubot<'a> {
                     values += ",";
                     str_gates += ",";
                 }
-                str_gates += &(*qubit.borrow()).name.to_string();
+                str_gates += &qubit.name.to_string();
 
-                if let Some(qubit_value) = self.get_qubit_value(qubit) {
+                if let Some(qubit_value) = self.get_qubit_value(*qubit) {
                     if qubit_value {
                         values += "1";
                     } else {
@@ -397,43 +338,35 @@ impl<'a> Qubot<'a> {
         writeln!(out)?;
 
         for (qubit, nid) in bad_state_qubits {
-            if let Some(qubit_value) = self.get_qubit_value(&qubit) {
-                writeln!(
-                    out,
-                    "{} {} {}",
-                    nid,
-                    (*qubit.borrow()).name,
-                    qubit_value as i32
-                )?;
+            if let Some(qubit_value) = self.get_qubit_value(qubit) {
+                writeln!(out, "{} {} {}", nid, qubit.name, qubit_value as i32)?;
             } else {
-                writeln!(out, "{} {}", nid, (*qubit.borrow()).name)?;
+                writeln!(out, "{} {}", nid, qubit.name)?;
             }
         }
 
         writeln!(out)?;
 
-        // TODO: If Qubits are always referenced by their `name: u64` this can
-        // be simplified by just typedef'ing `Qubit` instead.
-        let mut sorted_linear_coeffs: Vec<(&HashableQubitRef, &f64)> =
+        let mut sorted_linear_coeffs: Vec<(&Qubit, &f64)> =
             self.qubo.linear_coefficients.iter().collect();
-        sorted_linear_coeffs.sort_by_key(|(qubit, _)| (*qubit.value.borrow()).name);
+        sorted_linear_coeffs.sort_by_key(|(qubit, _)| qubit.name);
         for (qubit, coeff) in sorted_linear_coeffs {
-            let id = (*qubit.value.borrow()).name;
+            let id = qubit.name;
             writeln!(out, "{} {}", id, *coeff)?;
         }
 
         writeln!(out)?;
 
-        let mut sorted_quadratic_coeffs: Vec<(&HashableQubitRef, &HashMap<HashableQubitRef, f64>)> =
+        let mut sorted_quadratic_coeffs: Vec<(&Qubit, &HashMap<Qubit, f64>)> =
             self.qubo.quadratic_coefficients.iter().collect();
-        sorted_quadratic_coeffs.sort_by_key(|(qubit, _)| (*qubit.value.borrow()).name);
+        sorted_quadratic_coeffs.sort_by_key(|(qubit, _)| qubit.name);
         for (qubit1, edges) in sorted_quadratic_coeffs {
-            let id1 = (*qubit1.value.borrow()).name;
+            let id1 = qubit1.name;
 
-            let mut sorted_edges: Vec<(&HashableQubitRef, &f64)> = edges.iter().collect();
-            sorted_edges.sort_by_key(|(qubit, _)| (*qubit.value.borrow()).name);
+            let mut sorted_edges: Vec<(&Qubit, &f64)> = edges.iter().collect();
+            sorted_edges.sort_by_key(|(qubit, _)| qubit.name);
             for (qubit2, coeff) in sorted_edges {
-                let id2 = (*qubit2.value.borrow()).name;
+                let id2 = qubit2.name;
 
                 if id1 < id2 {
                     writeln!(out, "{} {} {}", id1, id2, *coeff)?;
@@ -449,13 +382,13 @@ impl<'a> Qubot<'a> {
         self.current_index
     }
 
-    fn update_mapping_carries(&mut self, gate: &GateRef, qubit_carry: QubitRef) {
+    fn update_mapping_carries(&mut self, gate: &GateRef, qubit_carry: Qubit) {
         let key = HashableGateRef::from(gate.clone());
         assert!(!self.mapping_carries.contains_key(&key));
         self.mapping_carries.insert(key, qubit_carry);
     }
 
-    fn visit(&mut self, gate: &GateRef) -> QubitRef {
+    fn visit(&mut self, gate: &GateRef) -> Qubit {
         let key = HashableGateRef::from(gate.clone());
 
         if self.mapping.contains_key(&key) {
@@ -468,28 +401,28 @@ impl<'a> Qubot<'a> {
             replacement
         }
     }
-    fn record_mapping(&mut self, gate: &GateRef, replacement: QubitRef) -> QubitRef {
+    fn record_mapping(&mut self, gate: &GateRef, replacement: Qubit) -> Qubit {
         let key = HashableGateRef::from(gate.clone());
         assert!(!self.mapping.contains_key(&key));
-        self.mapping.insert(key, replacement.clone());
+        self.mapping.insert(key, replacement);
         replacement
     }
 
-    pub fn process_gate(&mut self, gate: &GateRef) -> QubitRef {
+    pub fn process_gate(&mut self, gate: &GateRef) -> Qubit {
         match &*gate.borrow() {
-            Gate::ConstTrue {} => self.record_mapping(gate, self.const_true_qubit.clone()),
-            Gate::ConstFalse {} => self.record_mapping(gate, self.const_false_qubit.clone()),
+            Gate::ConstTrue {} => self.record_mapping(gate, self.const_true_qubit),
+            Gate::ConstFalse {} => self.record_mapping(gate, self.const_false_qubit),
             Gate::InputBit { name: _ } => {
-                let new_qubit = QubitRef::from(RefCell::new(Qubit {
+                let new_qubit = Qubit {
                     name: self.get_current_index(),
-                }));
-                self.qubo.add_rule(&new_qubit, Rule::Invalid);
+                };
+                self.qubo.add_rule(new_qubit, Rule::Invalid);
                 self.record_mapping(gate, new_qubit)
             }
             Gate::Quotient { index, .. } => {
-                let new_qubit = QubitRef::from(RefCell::new(Qubit {
+                let new_qubit = Qubit {
                     name: self.get_current_index(),
-                }));
+                };
 
                 let gate_key = HashableGateRef::from(gate.clone());
                 let nodes = self
@@ -507,7 +440,7 @@ impl<'a> Qubot<'a> {
                 let divisor = temp_gates.iter().map(|g| self.visit(g)).collect();
 
                 self.qubo.add_rule(
-                    &new_qubit,
+                    new_qubit,
                     Rule::Quotient {
                         dividend,
                         divisor,
@@ -517,9 +450,9 @@ impl<'a> Qubot<'a> {
                 self.record_mapping(gate, new_qubit)
             }
             Gate::Remainder { index, .. } => {
-                let new_qubit = QubitRef::from(RefCell::new(Qubit {
+                let new_qubit = Qubit {
                     name: self.get_current_index(),
-                }));
+                };
 
                 let gate_key = HashableGateRef::from(gate.clone());
                 let nodes = self
@@ -527,7 +460,7 @@ impl<'a> Qubot<'a> {
                     .constraint_based_dependencies
                     .get(&gate_key)
                     .unwrap();
-                let mut dividend: Vec<QubitRef> = Vec::new();
+                let mut dividend: Vec<Qubit> = Vec::new();
 
                 let mut node_key = HashableNodeRef::from(nodes.0.clone());
                 let mut temp_gates = self.gate_model.mapping.get(&node_key).unwrap();
@@ -535,14 +468,14 @@ impl<'a> Qubot<'a> {
                     dividend.push(self.visit(t_gate));
                 }
 
-                let mut divisor: Vec<QubitRef> = Vec::new();
+                let mut divisor: Vec<Qubit> = Vec::new();
                 node_key = HashableNodeRef::from(nodes.1.clone());
                 temp_gates = self.gate_model.mapping.get(&node_key).unwrap();
                 for t_gate in temp_gates {
                     divisor.push(self.visit(t_gate));
                 }
                 self.qubo.add_rule(
-                    &new_qubit,
+                    new_qubit,
                     Rule::Remainder {
                         dividend,
                         divisor,
@@ -553,147 +486,135 @@ impl<'a> Qubot<'a> {
             }
             Gate::Not { value } => {
                 let operand = self.visit(value);
-                let z = QubitRef::from(Qubit {
+                let z = Qubit {
                     name: self.get_current_index(),
-                });
+                };
 
-                self.qubo.add_linear_coeff(&operand, -2.0);
-                self.qubo.add_linear_coeff(&z, -2.0);
+                self.qubo.add_linear_coeff(operand, -2.0);
+                self.qubo.add_linear_coeff(z, -2.0);
 
-                self.qubo.add_quadratic_coeffs(&operand, &z, 4.0);
+                self.qubo.add_quadratic_coeffs(operand, z, 4.0);
                 self.qubo.add_offset(2.0);
 
-                self.qubo.add_rule(&z, Rule::Not { x1: operand });
+                self.qubo.add_rule(z, Rule::Not { x1: operand });
                 self.record_mapping(gate, z)
             }
             Gate::And { left, right } => {
                 let x1 = self.visit(left);
                 let x2 = self.visit(right);
-                let z = QubitRef::from(Qubit {
+                let z = Qubit {
                     name: self.get_current_index(),
-                });
+                };
 
-                self.qubo.add_linear_coeff(&x1, 0.0);
-                self.qubo.add_linear_coeff(&x2, 0.0);
-                self.qubo.add_linear_coeff(&z, 6.0);
+                self.qubo.add_linear_coeff(x1, 0.0);
+                self.qubo.add_linear_coeff(x2, 0.0);
+                self.qubo.add_linear_coeff(z, 6.0);
 
-                self.qubo.add_quadratic_coeffs(&x1, &x2, 2.0);
-                self.qubo.add_quadratic_coeffs(&x1, &z, -4.0);
-                self.qubo.add_quadratic_coeffs(&x2, &z, -4.0);
+                self.qubo.add_quadratic_coeffs(x1, x2, 2.0);
+                self.qubo.add_quadratic_coeffs(x1, z, -4.0);
+                self.qubo.add_quadratic_coeffs(x2, z, -4.0);
 
                 self.qubo.add_offset(0.0);
 
-                self.qubo.add_rule(&z, Rule::And { x1, x2 });
+                self.qubo.add_rule(z, Rule::And { x1, x2 });
                 self.record_mapping(gate, z)
             }
             Gate::Nand { left, right } => {
                 let x1 = self.visit(left);
                 let x2 = self.visit(right);
-                let z = QubitRef::from(Qubit {
+                let z = Qubit {
                     name: self.get_current_index(),
-                });
+                };
 
-                self.qubo.add_linear_coeff(&x1, -4.0);
-                self.qubo.add_linear_coeff(&x2, -4.0);
-                self.qubo.add_linear_coeff(&z, -6.0);
+                self.qubo.add_linear_coeff(x1, -4.0);
+                self.qubo.add_linear_coeff(x2, -4.0);
+                self.qubo.add_linear_coeff(z, -6.0);
 
-                self.qubo.add_quadratic_coeffs(&x1, &x2, 2.0);
-                self.qubo.add_quadratic_coeffs(&x1, &z, 4.0);
-                self.qubo.add_quadratic_coeffs(&x2, &z, 4.0);
+                self.qubo.add_quadratic_coeffs(x1, x2, 2.0);
+                self.qubo.add_quadratic_coeffs(x1, z, 4.0);
+                self.qubo.add_quadratic_coeffs(x2, z, 4.0);
 
                 self.qubo.add_offset(6.0);
 
-                self.qubo.add_rule(&z, Rule::Nand { x1, x2 });
+                self.qubo.add_rule(z, Rule::Nand { x1, x2 });
                 self.record_mapping(gate, z)
             }
             Gate::Matriarch1 { cond, right } => {
                 let x1 = self.visit(cond);
                 let x2 = self.visit(right);
-                let z = QubitRef::from(Qubit {
+                let z = Qubit {
                     name: self.get_current_index(),
-                });
+                };
 
-                self.qubo.add_linear_coeff(&x1, 0.0);
-                self.qubo.add_linear_coeff(&x2, 2.0);
-                self.qubo.add_linear_coeff(&z, 2.0);
+                self.qubo.add_linear_coeff(x1, 0.0);
+                self.qubo.add_linear_coeff(x2, 2.0);
+                self.qubo.add_linear_coeff(z, 2.0);
 
-                self.qubo.add_quadratic_coeffs(&x1, &x2, -2.0);
-                self.qubo.add_quadratic_coeffs(&x1, &z, 4.0);
-                self.qubo.add_quadratic_coeffs(&x2, &z, -4.0);
+                self.qubo.add_quadratic_coeffs(x1, x2, -2.0);
+                self.qubo.add_quadratic_coeffs(x1, z, 4.0);
+                self.qubo.add_quadratic_coeffs(x2, z, -4.0);
 
                 self.qubo.add_offset(0.0);
 
-                self.qubo.add_rule(&z, Rule::Matriarch1 { x1, x2 });
+                self.qubo.add_rule(z, Rule::Matriarch1 { x1, x2 });
                 self.record_mapping(gate, z)
             }
             Gate::Or { left, right } => {
                 let x1 = self.visit(left);
                 let x2 = self.visit(right);
-                let z = QubitRef::from(Qubit {
+                let z = Qubit {
                     name: self.get_current_index(),
-                });
+                };
 
-                self.qubo.add_linear_coeff(&x1, 2.0);
-                self.qubo.add_linear_coeff(&x2, 2.0);
-                self.qubo.add_linear_coeff(&z, 2.0);
+                self.qubo.add_linear_coeff(x1, 2.0);
+                self.qubo.add_linear_coeff(x2, 2.0);
+                self.qubo.add_linear_coeff(z, 2.0);
 
-                self.qubo.add_quadratic_coeffs(&x1, &x2, 2.0);
-                self.qubo.add_quadratic_coeffs(&x1, &z, -4.0);
-                self.qubo.add_quadratic_coeffs(&x2, &z, -4.0);
+                self.qubo.add_quadratic_coeffs(x1, x2, 2.0);
+                self.qubo.add_quadratic_coeffs(x1, z, -4.0);
+                self.qubo.add_quadratic_coeffs(x2, z, -4.0);
 
                 self.qubo.add_offset(0.0);
 
-                self.qubo.add_rule(&z, Rule::Or { x1, x2 });
+                self.qubo.add_rule(z, Rule::Or { x1, x2 });
                 self.record_mapping(gate, z)
             }
             Gate::ResultHalfAdder { input1, input2 } => {
                 let x1 = self.visit(input1);
                 let x2 = self.visit(input2);
 
-                let aux = QubitRef::from(Qubit {
+                let aux = Qubit {
                     name: self.get_current_index(),
-                });
-                let carry = QubitRef::from(Qubit {
+                };
+                let carry = Qubit {
                     name: self.get_current_index(),
-                });
-                let z = QubitRef::from(Qubit {
+                };
+                let z = Qubit {
                     name: self.get_current_index(),
-                });
+                };
 
-                self.update_mapping_carries(gate, carry.clone());
+                self.update_mapping_carries(gate, carry);
 
-                self.qubo.add_linear_coeff(&x1, 2.0);
-                self.qubo.add_linear_coeff(&x2, 2.0);
-                self.qubo.add_linear_coeff(&z, 2.0);
-                self.qubo.add_linear_coeff(&aux, 4.0);
-                self.qubo.add_linear_coeff(&carry, 4.0);
+                self.qubo.add_linear_coeff(x1, 2.0);
+                self.qubo.add_linear_coeff(x2, 2.0);
+                self.qubo.add_linear_coeff(z, 2.0);
+                self.qubo.add_linear_coeff(aux, 4.0);
+                self.qubo.add_linear_coeff(carry, 4.0);
 
-                self.qubo.add_quadratic_coeffs(&carry, &aux, 4.0);
-                self.qubo.add_quadratic_coeffs(&x1, &aux, -4.0);
-                self.qubo.add_quadratic_coeffs(&x1, &carry, -4.0);
-                self.qubo.add_quadratic_coeffs(&x2, &aux, 4.0);
-                self.qubo.add_quadratic_coeffs(&x2, &carry, -4.0);
-                self.qubo.add_quadratic_coeffs(&x1, &x2, 0.0);
-                self.qubo.add_quadratic_coeffs(&z, &aux, -4.0);
-                self.qubo.add_quadratic_coeffs(&z, &carry, 4.0);
-                self.qubo.add_quadratic_coeffs(&x1, &z, 0.0);
-                self.qubo.add_quadratic_coeffs(&x2, &z, -4.0);
+                self.qubo.add_quadratic_coeffs(carry, aux, 4.0);
+                self.qubo.add_quadratic_coeffs(x1, aux, -4.0);
+                self.qubo.add_quadratic_coeffs(x1, carry, -4.0);
+                self.qubo.add_quadratic_coeffs(x2, aux, 4.0);
+                self.qubo.add_quadratic_coeffs(x2, carry, -4.0);
+                self.qubo.add_quadratic_coeffs(x1, x2, 0.0);
+                self.qubo.add_quadratic_coeffs(z, aux, -4.0);
+                self.qubo.add_quadratic_coeffs(z, carry, 4.0);
+                self.qubo.add_quadratic_coeffs(x1, z, 0.0);
+                self.qubo.add_quadratic_coeffs(x2, z, -4.0);
 
-                self.qubo.add_rule(
-                    &carry,
-                    Rule::CarryHalfAdder {
-                        x1: x1.clone(),
-                        x2: x2.clone(),
-                    },
-                );
-                self.qubo.add_rule(
-                    &aux,
-                    Rule::AuxHalfAdder {
-                        x1: x1.clone(),
-                        x2: x2.clone(),
-                    },
-                );
-                self.qubo.add_rule(&z, Rule::ResultHalfAdder { x1, x2 });
+                self.qubo.add_rule(carry, Rule::CarryHalfAdder { x1, x2 });
+                self.qubo.add_rule(aux, Rule::AuxHalfAdder { x1, x2 });
+                self.qubo.add_rule(z, Rule::ResultHalfAdder { x1, x2 });
                 self.record_mapping(gate, z)
             }
             Gate::ResultFullAdder {
@@ -705,53 +626,40 @@ impl<'a> Qubot<'a> {
                 let x2 = self.visit(input2);
                 let x3 = self.visit(input3);
 
-                let aux = QubitRef::from(Qubit {
+                let aux = Qubit {
                     name: self.get_current_index(),
-                });
-                let carry = QubitRef::from(Qubit {
+                };
+                let carry = Qubit {
                     name: self.get_current_index(),
-                });
-                let z = QubitRef::from(Qubit {
+                };
+                let z = Qubit {
                     name: self.get_current_index(),
-                });
+                };
 
-                self.update_mapping_carries(gate, carry.clone());
+                self.update_mapping_carries(gate, carry);
 
-                self.qubo.add_linear_coeff(&x1, 2.0);
-                self.qubo.add_linear_coeff(&x2, 2.0);
-                self.qubo.add_linear_coeff(&x3, 2.0);
-                self.qubo.add_linear_coeff(&z, 2.0);
-                self.qubo.add_linear_coeff(&aux, 4.0);
-                self.qubo.add_linear_coeff(&carry, 4.0);
+                self.qubo.add_linear_coeff(x1, 2.0);
+                self.qubo.add_linear_coeff(x2, 2.0);
+                self.qubo.add_linear_coeff(x3, 2.0);
+                self.qubo.add_linear_coeff(z, 2.0);
+                self.qubo.add_linear_coeff(aux, 4.0);
+                self.qubo.add_linear_coeff(carry, 4.0);
 
-                self.qubo.add_quadratic_coeffs(&x1, &aux, -4.0);
-                self.qubo.add_quadratic_coeffs(&x1, &carry, -4.0);
-                self.qubo.add_quadratic_coeffs(&x2, &aux, -4.0);
-                self.qubo.add_quadratic_coeffs(&x2, &carry, -4.0);
-                self.qubo.add_quadratic_coeffs(&x1, &x2, 4.0);
-                self.qubo.add_quadratic_coeffs(&x3, &aux, 4.0);
-                self.qubo.add_quadratic_coeffs(&x3, &carry, -4.0);
-                self.qubo.add_quadratic_coeffs(&z, &aux, -4.0);
-                self.qubo.add_quadratic_coeffs(&z, &carry, 4.0);
-                self.qubo.add_quadratic_coeffs(&z, &x3, -4.0);
+                self.qubo.add_quadratic_coeffs(x1, aux, -4.0);
+                self.qubo.add_quadratic_coeffs(x1, carry, -4.0);
+                self.qubo.add_quadratic_coeffs(x2, aux, -4.0);
+                self.qubo.add_quadratic_coeffs(x2, carry, -4.0);
+                self.qubo.add_quadratic_coeffs(x1, x2, 4.0);
+                self.qubo.add_quadratic_coeffs(x3, aux, 4.0);
+                self.qubo.add_quadratic_coeffs(x3, carry, -4.0);
+                self.qubo.add_quadratic_coeffs(z, aux, -4.0);
+                self.qubo.add_quadratic_coeffs(z, carry, 4.0);
+                self.qubo.add_quadratic_coeffs(z, x3, -4.0);
 
-                self.qubo.add_rule(
-                    &carry,
-                    Rule::CarryFullAdder {
-                        x1: x1.clone(),
-                        x2: x2.clone(),
-                        x3: x3.clone(),
-                    },
-                );
-                self.qubo.add_rule(
-                    &aux,
-                    Rule::AuxFullAdder {
-                        x1: x1.clone(),
-                        x2: x2.clone(),
-                        x3: x3.clone(),
-                    },
-                );
-                self.qubo.add_rule(&z, Rule::ResultFullAdder { x1, x2, x3 });
+                self.qubo
+                    .add_rule(carry, Rule::CarryFullAdder { x1, x2, x3 });
+                self.qubo.add_rule(aux, Rule::AuxFullAdder { x1, x2, x3 });
+                self.qubo.add_rule(z, Rule::ResultFullAdder { x1, x2, x3 });
                 self.qubo.add_offset(0.0);
                 self.record_mapping(gate, z)
             }
@@ -761,7 +669,7 @@ impl<'a> Qubot<'a> {
                 self.visit(gate_half_adder);
 
                 let half_adder_key = HashableGateRef::from(gate_half_adder.clone());
-                let z = (*self.mapping_carries.get(&half_adder_key).unwrap()).clone();
+                let z = *self.mapping_carries.get(&half_adder_key).unwrap();
                 self.record_mapping(gate, z)
             }
             Gate::CarryFullAdder { .. } => {
@@ -770,14 +678,14 @@ impl<'a> Qubot<'a> {
                 self.visit(gate_full_adder);
 
                 let full_adder_key = HashableGateRef::from(gate_full_adder.clone());
-                let z = (*self.mapping_carries.get(&full_adder_key).unwrap()).clone();
+                let z = *self.mapping_carries.get(&full_adder_key).unwrap();
                 self.record_mapping(gate, z)
             }
         }
     }
 
-    pub fn build_qubo(&mut self) -> Vec<(QubitRef, u64)> {
-        let mut bad_state_qubits: Vec<(QubitRef, u64)> = Vec::new();
+    pub fn build_qubo(&mut self) -> Vec<(Qubit, u64)> {
+        let mut bad_state_qubits: Vec<(Qubit, u64)> = Vec::new();
         let bad_states_zipped = self
             .gate_model
             .bad_state_nodes
@@ -785,8 +693,7 @@ impl<'a> Qubot<'a> {
             .zip(self.gate_model.bad_state_gates.iter());
         for (node, gate) in bad_states_zipped {
             let qubit = self.process_gate(gate);
-            let key_qubit = HashableQubitRef::from(qubit.clone());
-            if !self.qubo.fixed_variables.contains_key(&key_qubit) {
+            if !self.qubo.fixed_variables.contains_key(&qubit) {
                 // only add qubits that does not have a fixed value
                 bad_state_qubits.push((qubit, get_nid(node)));
             }
@@ -794,33 +701,33 @@ impl<'a> Qubot<'a> {
 
         // or bad states
         if !bad_state_qubits.is_empty() {
-            let mut ored_bad_states = bad_state_qubits[0].0.clone();
+            let mut ored_bad_states = bad_state_qubits[0].0;
 
             for (qubit, _) in bad_state_qubits.iter().skip(1) {
                 // or bad state
-                let z = QubitRef::from(Qubit {
+                let z = Qubit {
                     name: self.get_current_index(),
-                });
-                self.qubo.add_linear_coeff(&ored_bad_states, 2.0);
-                self.qubo.add_linear_coeff(qubit, 2.0);
-                self.qubo.add_linear_coeff(&z, 2.0);
+                };
+                self.qubo.add_linear_coeff(ored_bad_states, 2.0);
+                self.qubo.add_linear_coeff(*qubit, 2.0);
+                self.qubo.add_linear_coeff(z, 2.0);
 
                 self.qubo.add_rule(
-                    &z,
+                    z,
                     Rule::Or {
-                        x1: ored_bad_states.clone(),
-                        x2: qubit.clone(),
+                        x1: ored_bad_states,
+                        x2: *qubit,
                     },
                 );
 
-                self.qubo.add_quadratic_coeffs(&ored_bad_states, qubit, 2.0);
-                self.qubo.add_quadratic_coeffs(&ored_bad_states, &z, -4.0);
-                self.qubo.add_quadratic_coeffs(qubit, &z, -4.0);
+                self.qubo.add_quadratic_coeffs(ored_bad_states, *qubit, 2.0);
+                self.qubo.add_quadratic_coeffs(ored_bad_states, z, -4.0);
+                self.qubo.add_quadratic_coeffs(*qubit, z, -4.0);
                 ored_bad_states = z;
             }
 
             // fix ored bad states to be true
-            self.qubo.fix_variable(&ored_bad_states, true);
+            self.qubo.fix_variable(ored_bad_states, true);
         } else {
             panic!("No bad states qubits!");
         }
@@ -828,14 +735,14 @@ impl<'a> Qubot<'a> {
         // apply constraints
         for (gate, value) in self.gate_model.constraints.iter() {
             let qubit = self.mapping.get(gate).unwrap();
-            self.qubo.fix_variable(qubit, *value);
+            self.qubo.fix_variable(*qubit, *value);
         }
 
         // fix true constants
-        self.qubo.fix_variable(&self.const_true_qubit, true);
+        self.qubo.fix_variable(self.const_true_qubit, true);
 
         //fix false constants
-        self.qubo.fix_variable(&self.const_false_qubit, false);
+        self.qubo.fix_variable(self.const_false_qubit, false);
 
         if self.qubo.is_ising {
             self.qubo.binary_to_ising();
@@ -846,7 +753,7 @@ impl<'a> Qubot<'a> {
 }
 
 pub struct InputEvaluator {
-    pub fixed_qubits: HashMap<HashableQubitRef, bool>,
+    pub fixed_qubits: HashMap<Qubit, bool>,
 }
 
 impl InputEvaluator {
@@ -856,11 +763,11 @@ impl InputEvaluator {
         }
     }
 
-    fn get_numeric_value(&mut self, qubits: &[QubitRef], qubo: &Qubo) -> u64 {
+    fn get_numeric_value(&mut self, qubits: &[Qubit], qubo: &Qubo) -> u64 {
         let mut result = 0;
         let mut current_power = 1;
         for qubit in qubits {
-            if self.get_qubit_value(qubit, qubo) {
+            if self.get_qubit_value(*qubit, qubo) {
                 result += current_power;
             }
             current_power *= 2;
@@ -868,18 +775,17 @@ impl InputEvaluator {
         result
     }
 
-    fn get_qubit_value(&mut self, z: &QubitRef, qubo: &Qubo) -> bool {
-        let key = HashableQubitRef::from(z.clone());
-        if let Some(value) = self.fixed_qubits.get(&key) {
+    fn get_qubit_value(&mut self, z: Qubit, qubo: &Qubo) -> bool {
+        if let Some(value) = self.fixed_qubits.get(&z) {
             return *value;
-        } else if let Some(value) = qubo.fixed_variables.get(&key) {
+        } else if let Some(value) = qubo.fixed_variables.get(&z) {
             return *value;
         }
-        let current_rule = qubo.rules.get(&key).unwrap();
+        let current_rule = qubo.rules.get(&z).unwrap();
         match current_rule {
             Rule::Not { x1 } => {
-                let value_x1 = self.get_qubit_value(x1, qubo);
-                self.fixed_qubits.insert(key, !value_x1);
+                let value_x1 = self.get_qubit_value(*x1, qubo);
+                self.fixed_qubits.insert(z, !value_x1);
                 !value_x1
             }
             Rule::Quotient {
@@ -921,31 +827,31 @@ impl InputEvaluator {
             | Rule::AuxHalfAdder { x1, x2 }
             | Rule::CarryHalfAdder { x1, x2 }
             | Rule::ResultHalfAdder { x1, x2 } => {
-                let value_x1 = self.get_qubit_value(x1, qubo);
-                let value_x2 = self.get_qubit_value(x2, qubo);
+                let value_x1 = self.get_qubit_value(*x1, qubo);
+                let value_x2 = self.get_qubit_value(*x2, qubo);
                 match current_rule {
                     Rule::And { .. } | Rule::CarryHalfAdder { .. } => {
-                        self.fixed_qubits.insert(key, value_x1 && value_x2);
+                        self.fixed_qubits.insert(z, value_x1 && value_x2);
                         value_x1 && value_x2
                     }
                     Rule::Nand { .. } => {
-                        self.fixed_qubits.insert(key, !(value_x1 && value_x2));
+                        self.fixed_qubits.insert(z, !(value_x1 && value_x2));
                         !(value_x1 && value_x2)
                     }
                     Rule::Matriarch1 { .. } => {
-                        self.fixed_qubits.insert(key, !value_x1 && value_x2);
+                        self.fixed_qubits.insert(z, !value_x1 && value_x2);
                         !value_x1 && value_x2
                     }
                     Rule::Or { .. } => {
-                        self.fixed_qubits.insert(key, value_x1 || value_x2);
+                        self.fixed_qubits.insert(z, value_x1 || value_x2);
                         value_x1 || value_x2
                     }
                     Rule::AuxHalfAdder { .. } => {
-                        self.fixed_qubits.insert(key, value_x1 && !value_x2);
+                        self.fixed_qubits.insert(z, value_x1 && !value_x2);
                         value_x1 && !value_x2
                     }
                     Rule::ResultHalfAdder { .. } => {
-                        self.fixed_qubits.insert(key, value_x1 != value_x2);
+                        self.fixed_qubits.insert(z, value_x1 != value_x2);
                         value_x1 != value_x2
                     }
                     _ => {
@@ -956,9 +862,9 @@ impl InputEvaluator {
             Rule::AuxFullAdder { x1, x2, x3 }
             | Rule::CarryFullAdder { x1, x2, x3 }
             | Rule::ResultFullAdder { x1, x2, x3 } => {
-                let value_x1 = self.get_qubit_value(x1, qubo);
-                let value_x2 = self.get_qubit_value(x2, qubo);
-                let value_x3 = self.get_qubit_value(x3, qubo);
+                let value_x1 = self.get_qubit_value(*x1, qubo);
+                let value_x2 = self.get_qubit_value(*x2, qubo);
+                let value_x3 = self.get_qubit_value(*x3, qubo);
 
                 match current_rule {
                     Rule::AuxFullAdder { .. } => {
@@ -979,18 +885,18 @@ impl InputEvaluator {
                             aux = true;
                         }
 
-                        self.fixed_qubits.insert(key, aux);
+                        self.fixed_qubits.insert(z, aux);
                         aux
                     }
                     Rule::CarryFullAdder { .. } => {
                         let result = (value_x1 as i32) + (value_x2 as i32) + (value_x3 as i32) > 1;
-                        self.fixed_qubits.insert(key, result);
+                        self.fixed_qubits.insert(z, result);
                         result
                     }
                     Rule::ResultFullAdder { .. } => {
                         let result =
                             (((value_x1 as i32) + (value_x2 as i32) + (value_x3 as i32)) % 2) == 1;
-                        self.fixed_qubits.insert(key, result);
+                        self.fixed_qubits.insert(z, result);
                         result
                     }
                     _ => {
@@ -1007,10 +913,10 @@ impl InputEvaluator {
     pub fn evaluate_inputs(
         &mut self,
         qubo: &Qubo,
-        mapping: &HashMap<HashableGateRef, QubitRef>,
+        mapping: &HashMap<HashableGateRef, Qubit>,
         input_gates: &[(NodeRef, Vec<GateRef>)],
         input_values: &[i64],
-        bad_states: Vec<(QubitRef, u64)>,
+        bad_states: Vec<(Qubit, u64)>,
     ) -> (f64, Vec<u64>) {
         assert!(input_gates.len() == input_values.len());
 
@@ -1020,9 +926,8 @@ impl InputEvaluator {
             let gates: Vec<GateRef> = gates.1.to_vec();
             for gate in gates {
                 let gate_key = HashableGateRef::from(gate);
-                let qubit_ref = &*(mapping.get(&gate_key).unwrap());
-                let qubit_key = HashableQubitRef::from(qubit_ref.clone());
-                self.fixed_qubits.insert(qubit_key, (current_val % 2) == 1);
+                let qubit = mapping.get(&gate_key).unwrap();
+                self.fixed_qubits.insert(*qubit, (current_val % 2) == 1);
                 current_val /= 2;
             }
         }
@@ -1031,7 +936,7 @@ impl InputEvaluator {
         let mut offset = qubo.offset;
 
         for (qubit_hash, coeff) in qubo.linear_coefficients.iter() {
-            let qubit_value = self.get_qubit_value(&qubit_hash.value, qubo);
+            let qubit_value = self.get_qubit_value(*qubit_hash, qubo);
             let final_value: f64;
             if qubo.is_ising && !qubit_value {
                 final_value = -1.0;
@@ -1042,13 +947,13 @@ impl InputEvaluator {
         }
 
         for (qubit_hash1, more_qubits) in qubo.quadratic_coefficients.iter() {
-            let mut value1 = (self.get_qubit_value(&qubit_hash1.value, qubo) as i64) as f64;
+            let mut value1 = (self.get_qubit_value(*qubit_hash1, qubo) as i64) as f64;
             if qubo.is_ising && value1 == 0.0 {
                 value1 = -1.0;
             }
             for (qubit_hash2, coeff) in more_qubits.iter() {
-                if qubit_hash1.value.borrow().name < qubit_hash2.value.borrow().name {
-                    let mut value2 = (self.get_qubit_value(&qubit_hash2.value, qubo) as i64) as f64;
+                if qubit_hash1.name < qubit_hash2.name {
+                    let mut value2 = (self.get_qubit_value(*qubit_hash2, qubo) as i64) as f64;
 
                     if qubo.is_ising && value2 == 0.0 {
                         value2 = -1.0;
@@ -1061,7 +966,7 @@ impl InputEvaluator {
         let mut true_bad_states = vec![];
         // which bad states happen? :
         for (qubit, nid) in bad_states {
-            let value = self.get_qubit_value(&qubit, qubo);
+            let value = self.get_qubit_value(qubit, qubo);
             if value {
                 true_bad_states.push(nid);
             }


### PR DESCRIPTION
This simplifies the `Qubit` struct used to identify a qubit variable
when generating a Qubo. Since the qubit is identified directly via its
unique name (i.e. a `u64` value) and we do not form graph structures
with qubits, there is no need to count references to them or to manage
their memeory. We simply pass `Qubit` by value now.

This is a pure refactoring, no functional changes intended.