### PR TITLE
Fix Emulator: div traced as "divu"

### DIFF
--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -810,7 +810,7 @@ fn exec_div(state: &mut EmulatorState, rtype: RType) {
     let rs2_value = state.get_reg(rtype.rs2());
     assert!(rs2_value != 0, "check for non-zero divisor");
     let rd_value = (rs1_value as i64).wrapping_div(rs2_value as i64) as u64;
-    trace_rtype(state, "divu", rtype, rd_value);
+    trace_rtype(state, "div", rtype, rd_value);
     state.set_reg(rtype.rd(), rd_value);
     state.pc_next();
 }


### PR DESCRIPTION
"exec_divu" calls "trace_rtype("divu"...).
"exec_div" also calls "trace_rtype("divu"...) but I believe it should only pass "div" as param.

I came upon this while further studying the code. I am not confident enough yet to 100% call this a typo, since maybe it is intended. But I have not seen this behaviour with other instructions so I would assume it is, in fact, a typo (assuming this is done for logging purposes).