### PR TITLE
Emulator: Gcc binary support (#1)

### DIFF
--- a/examples/count_up_down-1.c
+++ b/examples/count_up_down-1.c
@@ -27,7 +27,7 @@ uint64_t main() {
 
   read(0, n, 8); 
 
-  x = n;
+  x = *n;
   y = 0;
 
   while(x > 0) {

--- a/examples/main-return-1.c
+++ b/examples/main-return-1.c
@@ -1,0 +1,3 @@
+uint64_t main() {
+  return 42;
+}

--- a/examples/main-return-2.c
+++ b/examples/main-return-2.c
@@ -1,0 +1,7 @@
+uint64_t main() {
+  int x;
+
+  x = 42;
+
+  return x;
+}

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -837,7 +837,7 @@ fn exec_div(state: &mut EmulatorState, rtype: RType) {
 fn exec_divw(state: &mut EmulatorState, rtype: RType) {
     let rs1_value = state.get_reg(rtype.rs1());
     let rs2_value = state.get_reg(rtype.rs2());
-    assert!(rs2_value != 0, "check for non-zero divisor");
+    assert!((rs2_value as i32) != 0, "check for non-zero divisor");
     let rd_value = (rs1_value as i32).wrapping_div(rs2_value as i32) as u64;
     trace_rtype(state, "divw", rtype, rd_value);
     state.set_reg(rtype.rd(), rd_value);
@@ -873,7 +873,7 @@ fn exec_rem(state: &mut EmulatorState, rtype: RType) {
 fn exec_remw(state: &mut EmulatorState, rtype: RType) {
     let rs1_value = state.get_reg(rtype.rs1());
     let rs2_value = state.get_reg(rtype.rs2());
-    assert!(rs2_value != 0, "check for non-zero divisor");
+    assert!((rs2_value as i32) != 0, "check for non-zero divisor");
     let rd_value = (rs1_value  as i32).wrapping_rem(rs2_value  as i32)  as u64;
     trace_rtype(state, "remw", rtype, rd_value);
     state.set_reg(rtype.rd(), rd_value);

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -820,7 +820,7 @@ fn exec_mulw(state: &mut EmulatorState, rtype: RType) {
     state.pc_next();
 }
 
-// rd = rs1 / rs2
+// rd = rs1 /s rs2
 // pc = pc + 4
 fn exec_div(state: &mut EmulatorState, rtype: RType) {
     let rs1_value = state.get_reg(rtype.rs1());
@@ -832,7 +832,7 @@ fn exec_div(state: &mut EmulatorState, rtype: RType) {
     state.pc_next();
 }
 
-// rd = s64(rs1{32} / rs2{32})
+// rd = s64(rs1{32} /s rs2{32})
 // pc = pc + 4
 fn exec_divw(state: &mut EmulatorState, rtype: RType) {
     let rs1_value = state.get_reg(rtype.rs1());
@@ -856,7 +856,7 @@ fn exec_divu(state: &mut EmulatorState, rtype: RType) {
     state.pc_next();
 }
 
-// rd = rs1 % rs2
+// rd = rs1 %s rs2
 // pc = pc + 4
 fn exec_rem(state: &mut EmulatorState, rtype: RType) {
     let rs1_value = state.get_reg(rtype.rs1());
@@ -868,7 +868,7 @@ fn exec_rem(state: &mut EmulatorState, rtype: RType) {
     state.pc_next();
 }
 
-// rd = s64(rs1{32} % rs2{32})
+// rd = s64(rs1{32} %s rs2{32})
 // pc = pc + 4
 fn exec_remw(state: &mut EmulatorState, rtype: RType) {
     let rs1_value = state.get_reg(rtype.rs1());

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -265,6 +265,7 @@ fn execute(state: &mut EmulatorState, instr: Instruction) {
         Instruction::Add(rtype) => exec_add(state, rtype),
         Instruction::Sub(rtype) => exec_sub(state, rtype),
         Instruction::Sll(rtype) => exec_sll(state, rtype),
+        Instruction::Slt(rtype) => exec_slt(state, rtype),
         Instruction::Sltu(rtype) => exec_sltu(state, rtype),
         Instruction::Srl(rtype) => exec_srl(state, rtype),
         Instruction::Sra(rtype) => exec_sra(state, rtype),
@@ -273,11 +274,14 @@ fn execute(state: &mut EmulatorState, instr: Instruction) {
         Instruction::Mul(rtype) => exec_mul(state, rtype),
         Instruction::Div(rtype) => exec_div(state, rtype),
         Instruction::Divu(rtype) => exec_divu(state, rtype),
+        Instruction::Rem(rtype) => exec_rem(state, rtype),
         Instruction::Remu(rtype) => exec_remu(state, rtype),
         Instruction::Addw(rtype) => exec_addw(state, rtype),
         Instruction::Subw(rtype) => exec_subw(state, rtype),
         Instruction::Sllw(rtype) => exec_sllw(state, rtype),
         Instruction::Mulw(rtype) => exec_mulw(state, rtype),
+        Instruction::Divw(rtype) => exec_divw(state, rtype),
+        Instruction::Remw(rtype) => exec_remw(state, rtype),
         Instruction::Ecall(_itype) => exec_ecall(state),
         // TODO: Cover all needed instructions here.
         _ => unimplemented!("not implemented: {:?}", instr),
@@ -746,6 +750,19 @@ fn exec_sra(state: &mut EmulatorState, rtype: RType) {
     state.pc_next();
 }
 
+// rd = 1                     ||| if (rs1 < rs2)
+// rd = 0                     ||| otherwise
+// pc = pc + 4
+fn exec_slt(state: &mut EmulatorState, rtype: RType) {
+    let rs1_value = state.get_reg(rtype.rs1());
+    let rs2_value = state.get_reg(rtype.rs2());
+    let condition = (rs1_value as i64) < (rs2_value as i64);
+    let rd_value = EmulatorValue::from(condition);
+    trace_rtype(state, "slt", rtype, rd_value);
+    state.set_reg(rtype.rd(), rd_value);
+    state.pc_next();
+}
+
 // rd = 1                     ||| if (rs1 <u rs2)
 // rd = 0                     ||| otherwise
 // pc = pc + 4
@@ -803,7 +820,7 @@ fn exec_mulw(state: &mut EmulatorState, rtype: RType) {
     state.pc_next();
 }
 
-// rd = rs1 /s rs2
+// rd = rs1 / rs2
 // pc = pc + 4
 fn exec_div(state: &mut EmulatorState, rtype: RType) {
     let rs1_value = state.get_reg(rtype.rs1());
@@ -811,6 +828,18 @@ fn exec_div(state: &mut EmulatorState, rtype: RType) {
     assert!(rs2_value != 0, "check for non-zero divisor");
     let rd_value = (rs1_value as i64).wrapping_div(rs2_value as i64) as u64;
     trace_rtype(state, "div", rtype, rd_value);
+    state.set_reg(rtype.rd(), rd_value);
+    state.pc_next();
+}
+
+// rd = s64(rs1{32} / rs2{32})
+// pc = pc + 4
+fn exec_divw(state: &mut EmulatorState, rtype: RType) {
+    let rs1_value = state.get_reg(rtype.rs1());
+    let rs2_value = state.get_reg(rtype.rs2());
+    assert!(rs2_value != 0, "check for non-zero divisor");
+    let rd_value = (rs1_value as i32).wrapping_div(rs2_value as i32) as u64;
+    trace_rtype(state, "divw", rtype, rd_value);
     state.set_reg(rtype.rd(), rd_value);
     state.pc_next();
 }
@@ -823,6 +852,30 @@ fn exec_divu(state: &mut EmulatorState, rtype: RType) {
     assert!(rs2_value != 0, "check for non-zero divisor");
     let rd_value = rs1_value.wrapping_div(rs2_value);
     trace_rtype(state, "divu", rtype, rd_value);
+    state.set_reg(rtype.rd(), rd_value);
+    state.pc_next();
+}
+
+// rd = rs1 % rs2
+// pc = pc + 4
+fn exec_rem(state: &mut EmulatorState, rtype: RType) {
+    let rs1_value = state.get_reg(rtype.rs1());
+    let rs2_value = state.get_reg(rtype.rs2());
+    assert!(rs2_value != 0, "check for non-zero divisor");
+    let rd_value = (rs1_value  as i64).wrapping_rem(rs2_value  as i64)  as u64;
+    trace_rtype(state, "rem", rtype, rd_value);
+    state.set_reg(rtype.rd(), rd_value);
+    state.pc_next();
+}
+
+// rd = s64(rs1{32} % rs2{32})
+// pc = pc + 4
+fn exec_remw(state: &mut EmulatorState, rtype: RType) {
+    let rs1_value = state.get_reg(rtype.rs1());
+    let rs2_value = state.get_reg(rtype.rs2());
+    assert!(rs2_value != 0, "check for non-zero divisor");
+    let rd_value = (rs1_value  as i32).wrapping_rem(rs2_value  as i32)  as u64;
+    trace_rtype(state, "remw", rtype, rd_value);
     state.set_reg(rtype.rd(), rd_value);
     state.pc_next();
 }
@@ -851,10 +904,16 @@ fn exec_ecall(state: &mut EmulatorState) {
         syscall_read(state);
     } else if a7_value == SyscallId::Write as u64 {
         syscall_write(state);
+    } else if a7_value == SyscallId::Open as u64 {
+        syscall_open(state);
     } else if a7_value == SyscallId::Openat as u64 {
         syscall_openat(state);
     } else if a7_value == SyscallId::Brk as u64 {
         syscall_brk(state);
+    } else if a7_value == SyscallId::Close as u64 {
+        // TODO close system call
+    } else if a7_value == SyscallId::Newfstat as u64 {
+        // TODO newfstat system call
     } else {
         warn!("unknown system call: {}", a7_value);
         state.set_reg(Register::A0, u64::MAX);
@@ -911,6 +970,26 @@ fn syscall_write(state: &mut EmulatorState) {
 
     state.set_reg(Register::A0, result);
     debug!("write({},{:#x},{}) -> {}", fd, buffer, size, result);
+}
+
+fn syscall_open(state: &mut EmulatorState) {
+    let path = state.get_reg(Register::A0);
+    let flag = state.get_reg(Register::A1);
+    let mode = state.get_reg(Register::A2);
+    let temp = state.get_reg(Register::A3);
+
+    // TODO Set fd to AT_FDCWD
+    // state.set_reg(Register::A0, AT_FDCWD);
+    state.set_reg(Register::A1, path);
+    state.set_reg(Register::A2, flag);
+    state.set_reg(Register::A3, mode);
+
+    syscall_openat(state);
+
+    // needed?
+    state.set_reg(Register::A1, flag);
+    state.set_reg(Register::A2, mode);
+    state.set_reg(Register::A3, temp);
 }
 
 fn syscall_openat(state: &mut EmulatorState) {

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -750,7 +750,7 @@ fn exec_sra(state: &mut EmulatorState, rtype: RType) {
     state.pc_next();
 }
 
-// rd = 1                     ||| if (rs1 < rs2)
+// rd = 1                     ||| if (rs1 <s rs2)
 // rd = 0                     ||| otherwise
 // pc = pc + 4
 fn exec_slt(state: &mut EmulatorState, rtype: RType) {

--- a/src/engine/system.rs
+++ b/src/engine/system.rs
@@ -8,8 +8,11 @@ pub enum SyscallId {
     Exit = 93,
     Read = 63,
     Write = 64,
+    Open = 1024,
     Openat = 56,
     Brk = 214,
+    Close = 57,
+    Newfstat = 80
 }
 
 // Prepares arguments on the stack like a UNIX system. Note that we


### PR DESCRIPTION
This was our task list (everything checked):
- Add remaining instructions (Rem, Div, Remw, Divw etc.)
- Support read() systemcall
- All read() examples work on unicorn emulator (excluding open())
- Support write() systemcall
- All write() examples work on unicorn emulator (excluding open())
- Support open() systemcall
- All open() examples work on unicorn emulator
- Selfie works on unicorn emulator

Notes:
- Some system calls (Close, Newfstat) are emitted by the cross-compiler but did not require an actual implementation in the emulator, it works without them.
- There are additional examples we added for testing and did not remove. They can be removed, of course.

Selfie was changed to be compilable by the cross-compiler. Details here: https://github.com/cksystemsteaching/selfie/pull/346

Result of running this version of selfie on the emulator:
![grafik](https://user-images.githubusercontent.com/41904979/211331486-1879b3d6-672c-4b3b-9b09-f376aad656e7.png)
