### PR TITLE
Apply clippy suggestions to make pre-commit hook pass.

### DIFF
--- a/src/guinea/cli2gui.rs
+++ b/src/guinea/cli2gui.rs
@@ -342,7 +342,7 @@ fn is_concurrent(data: &mut Guineacorn) -> bool {
             if !thread.is_finished() {
                 return true;
             }
-            let thread = std::mem::replace(&mut data.loading_data.processing_thread, None).unwrap();
+            let thread = data.loading_data.processing_thread.take().unwrap();
             let serial_model = thread.join();
             match serial_model {
                 Ok(model) => {

--- a/src/guinea/giraphe/graph.rs
+++ b/src/guinea/giraphe/graph.rs
@@ -287,7 +287,7 @@ impl Giraphe {
     }
 
     pub(crate) fn evaluate(&mut self, nid: &Nid) -> Value {
-        let mut spot = self.node_lookup.get_mut(nid).unwrap();
+        let spot = self.node_lookup.get_mut(nid).unwrap();
         spot.old_value = spot.current_value.clone();
 
         if self.tick == spot.tick {
@@ -492,7 +492,7 @@ impl Giraphe {
             Node::Comment(_) => unreachable!(),
         };
 
-        let mut spot = self.node_lookup.get_mut(nid).unwrap();
+        let spot = self.node_lookup.get_mut(nid).unwrap();
         spot.current_value = new_value.clone();
         new_value
     }

--- a/src/unicorn/qubot.rs
+++ b/src/unicorn/qubot.rs
@@ -877,17 +877,13 @@ impl InputEvaluator {
                         if !value_x1 {
                             if !value_x2 {
                                 aux = false;
-                            } else if !value_x3 {
-                                aux = true;
                             } else {
-                                aux = false;
+                                aux = !value_x3;
                             }
                         } else if value_x2 {
                             aux = true;
-                        } else if value_x3 {
-                            aux = false;
                         } else {
-                            aux = true;
+                            aux = !value_x3;
                         }
 
                         self.fixed_qubits.insert(z, aux);


### PR DESCRIPTION
Fixes #62.

It seems that either `clippy` added some rules or some merged code has been checked in without the pre-commit hook running. This PR applies the suggested fixes.

Applied fixes for reference:
  - remove unnecessary `mut`
  - https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_option_with_none
  - https://rust-lang.github.io/rust-clippy/master/index.html#needless_bool_assign
 